### PR TITLE
Upgrade to 1.5.6 and create datasource proxy to be inline with 2.0.0.M3

### DIFF
--- a/jndi-embedded-example/pom.xml
+++ b/jndi-embedded-example/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.5.4.RELEASE</version>
+    <version>1.5.6.RELEASE</version>
     <relativePath/>
   </parent>
 

--- a/jndi-external-example/pom.xml
+++ b/jndi-external-example/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.5.4.RELEASE</version>
+    <version>1.5.6.RELEASE</version>
     <relativePath/>
   </parent>
 

--- a/spring-javaconfig-example/pom.xml
+++ b/spring-javaconfig-example/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.5.4.RELEASE</version>
+    <version>1.5.6.RELEASE</version>
     <relativePath/>
   </parent>
 

--- a/springboot-autoconfig-example/pom.xml
+++ b/springboot-autoconfig-example/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.5.4.RELEASE</version>
+    <version>1.5.6.RELEASE</version>
     <relativePath/>
   </parent>
 

--- a/springboot-autoconfig-example/src/main/java/net/ttddyy/dsproxy/example/DatasourceProxyBeanPostProcessor.java
+++ b/springboot-autoconfig-example/src/main/java/net/ttddyy/dsproxy/example/DatasourceProxyBeanPostProcessor.java
@@ -1,9 +1,14 @@
 package net.ttddyy.dsproxy.example;
 
+import java.lang.reflect.Method;
 import javax.sql.DataSource;
 
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.stereotype.Component;
+import org.springframework.util.ReflectionUtils;
 
 import net.ttddyy.dsproxy.listener.logging.SLF4JLogLevel;
 import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
@@ -14,9 +19,10 @@ public class DatasourceProxyBeanPostProcessor implements BeanPostProcessor {
     @Override
     public Object postProcessAfterInitialization(Object bean, String beanName) {
         if (bean instanceof DataSource) {
-            DataSource dataSourceBean = (DataSource) bean;
-            return ProxyDataSourceBuilder.create(dataSourceBean).name("MyDS").multiline()
-                    .logQueryBySlf4j(SLF4JLogLevel.INFO).build();
+            final ProxyFactory factory = new ProxyFactory(bean);
+            factory.setProxyTargetClass(true);
+            factory.addAdvice(new ProxyDataSourceInterceptor((DataSource) bean));
+            return factory.getProxy();
         }
         return bean;
     }
@@ -26,4 +32,23 @@ public class DatasourceProxyBeanPostProcessor implements BeanPostProcessor {
         return bean;
     }
 
+    private static class ProxyDataSourceInterceptor implements MethodInterceptor {
+        private final DataSource dataSource;
+
+        public ProxyDataSourceInterceptor(final DataSource dataSource) {
+            super();
+            this.dataSource = ProxyDataSourceBuilder.create(dataSource).name("MyDS").multiline()
+                    .logQueryBySlf4j(SLF4JLogLevel.INFO).build();
+        }
+
+        @Override
+        public Object invoke(final MethodInvocation invocation) throws Throwable {
+            final Method proxyMethod = ReflectionUtils.findMethod(dataSource.getClass(),
+                    invocation.getMethod().getName());
+            if (proxyMethod != null) {
+                return proxyMethod.invoke(dataSource, invocation.getArguments());
+            }
+            return invocation.proceed();
+        }
+    }
 }


### PR DESCRIPTION
With spring 2.0.0.M3 creation of proxies is changed, to be in line with this change using AOP in lower versions too to create datasource proxy automatically.

With this change user can change to 2.0.0.M3+ version of spring boot